### PR TITLE
new featch

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,24 @@ sudo ./k8s/auto-k8s-smart-reboot.sh
 
 ## VPN конфигурация
 
+### Автоматическая генерация XRAY-конфига
+
+Для повышения безопасности и удобства, все ключевые параметры XRAY (UUID, приватный ключ, короткий id, DNS) генерируются автоматически при запуске скрипта:
+
+```bash
+cd k8s/xray
+chmod +x generate-xray-config.sh
+./generate-xray-config.sh <dns_address>
+```
+
+Параметры сохраняются в файл `xray-params.env`, а итоговый конфиг для деплоя создается как `xray-configmap.generated.yaml`.
+Скрипт также выводит готовую ссылку для подключения к VPN.
+
+**Для деплоя используйте файл xray-configmap.generated.yaml**
+
+
 ### XRay Client Config (для подключения)
+Параметры для подключения берите из вывода скрипта или файла `xray-params.env`.
 
 ```json
 {

--- a/k8s/xray/generate-xray-config.sh
+++ b/k8s/xray/generate-xray-config.sh
@@ -1,0 +1,41 @@
+# Скрипт для генерации уникальных параметров и конфигов XRAY
+# Использование: ./generate-xray-config.sh <dns_address>
+
+set -e
+
+# Генерация UUID для id
+ID=$(cat /proc/sys/kernel/random/uuid)
+
+# Генерация приватного ключа (32 символа base64)
+PRIVATE_KEY=$(head -c 32 /dev/urandom | base64 | tr -d '=+/')
+
+# Генерация shortId (8 цифр)
+SHORT_ID=$(shuf -i 10000000-99999999 -n 1)
+
+# DNS по умолчанию
+DEFAULT_DNS="tls://1.1.1.1"
+DNS_ADDRESS=${1:-$DEFAULT_DNS}
+
+# Папка со скриптом
+DIR=$(dirname "$0")
+
+# Сохраняем параметры в env-файл
+cat <<EOF > "$DIR/xray-params.env"
+ID="$ID"
+PRIVATE_KEY="$PRIVATE_KEY"
+SHORT_ID="$SHORT_ID"
+DNS_ADDRESS="$DNS_ADDRESS"
+EOF
+
+# Генерируем итоговый конфиг XRAY для деплоя
+envsubst < "$DIR/xray-configmap.yaml" > "$DIR/xray-configmap.generated.yaml"
+
+# Инструкция для подключения
+echo "\nПараметры XRAY VPN сгенерированы:"
+echo "ID: $ID"
+echo "PRIVATE_KEY: $PRIVATE_KEY"
+echo "SHORT_ID: $SHORT_ID"
+echo "DNS_ADDRESS: $DNS_ADDRESS"
+echo "\nСсылка для подключения (пример):"
+echo "vless://$ID@<SERVER_IP>:443?encryption=none&security=reality&sni=www.google.com&fp=chrome&pbk=$PRIVATE_KEY&sid=$SHORT_ID&type=tcp&flow=xtls-rprx-vision#XRAY-VPN"
+echo "\nДля деплоя используйте файл xray-configmap.generated.yaml"

--- a/k8s/xray/xray-configmap.yaml
+++ b/k8s/xray/xray-configmap.yaml
@@ -9,10 +9,11 @@ data:
       "log": {
         "loglevel": "warning"
       },
+      # DNS адрес берется из переменной окружения
       "dns": {
         "servers": [
           {
-            "address": "tls://ee1e197c.d.adguard-dns.com"
+            "address": "${DNS_ADDRESS}"
           }
         ]
       },
@@ -23,7 +24,8 @@ data:
           "settings": {
             "clients": [
               {
-                "id": "c7b52032-1694-40ee-9b3d-3b1667520944",
+                # UUID клиента берется из переменной окружения
+                "id": "${ID}",
                 "flow": "xtls-rprx-vision"
               }
             ],
@@ -37,8 +39,9 @@ data:
               "dest": "www.google.com:443",
               "xver": 0,
               "serverNames": [ "www.google.com" ],
-              "privateKey": "cM4_ApqKwF1Dy-jfBJr8Lo5oj8CPLT7Dg61cMxnQwkE",
-              "shortIds": [ "22334455" ]
+              # Приватный ключ и короткий id берутся из переменных окружения
+              "privateKey": "${PRIVATE_KEY}",
+              "shortIds": [ "${SHORT_ID}" ]
             }
           }
         }

--- a/k8s/xray/xray-params.env.example
+++ b/k8s/xray/xray-params.env.example
@@ -1,0 +1,6 @@
+# Этот файл подгружается в xray-configmap.yaml через envsubst или аналогичный механизм
+# Пример использования: envsubst < xray-configmap.yaml > xray-configmap.generated.yaml
+ID=""
+PRIVATE_KEY=""
+SHORT_ID=""
+DNS_ADDRESS=""


### PR DESCRIPTION
Вынес параметры id, privateKey, shortIds, address в отдельный файл переменных окружения (xray-params.env), добавил пример (xray-params.env.example).

Обновил xray-configmap.yaml для использования этих переменных через шаблоны ${...}.

Создал скрипт generate-xray-config.sh для генерации уникальных ключей и выбора DNS (по умолчанию 1.1.1.1 или пользовательский).

Скрипт выводит параметры и готовую ссылку для подключения к VPN.